### PR TITLE
Update for repo best practices

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,20 +4,20 @@ dart:
 - dev
 - 2.1.1
 
+dart_task:
+  - test: -p vm,chrome
+
 matrix:
   include:
   - dart: dev
     dart_task:
-      - dartanalyzer
       - dartfmt
   - dart: dev
     dart_task:
-      - test: -p vm
-      - test: -p chrome
+      - dartanalyzer: --fatal-lints --fatal-warnings .
   - dart: 2.1.1
     dart_task:
-      - test: -p vm
-      - test: -p chrome
+      - dartanalyzer: --fatal-warnings .
 
 # Only building master means that we don't run two builds for each pull request.
 branches:

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,14 +10,13 @@ dart_task:
 matrix:
   include:
   - dart: dev
-    dart_task:
-      - dartfmt
+    dart_task: dartfmt
   - dart: dev
     dart_task:
-      - dartanalyzer: --fatal-lints --fatal-warnings .
+      dartanalyzer: --fatal-lints --fatal-warnings .
   - dart: 2.1.1
     dart_task:
-      - dartanalyzer: --fatal-warnings .
+      dartanalyzer: --fatal-warnings .
 
 # Only building master means that we don't run two builds for each pull request.
 branches:

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,15 +4,20 @@ dart:
 - dev
 - 2.1.1
 
-dart_task:
-  - test
-
 matrix:
   include:
   - dart: dev
-    dart_task: dartanalyzer
+    dart_task:
+      - dartanalyzer
+      - dartfmt
   - dart: dev
-    dart_task: dartfmt
+    dart_task:
+      - test: -p vm
+      - test: -p chrome
+  - dart: 2.1.1
+    dart_task:
+      - test: -p vm
+      - test: -p chrome
 
 # Only building master means that we don't run two builds for each pull request.
 branches:

--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@ Different `Clock`s can have a different notion of the current time, and the
 default top-level [`clock`][]'s notion can be swapped out to reliably test
 timing-dependent code.
 
-[`Clock`]: https://www.dartdocs.org/documentation/clock/latest/clock/Clock-class.html
-[`clock`]: https://www.dartdocs.org/documentation/clock/latest/clock/clock.html
+[`Clock`]: https://pub.dev/documentation/clock/latest/clock/Clock-class.html
+[`clock`]: https://pub.dev/documentation/clock/latest/clock/clock.html
 
 For example, you can use `clock` in your libraries like this:
 
@@ -14,7 +14,7 @@ For example, you can use `clock` in your libraries like this:
 import 'package:clock/clock.dart';
 
 /// Runs [callback] and prints how long it took.
-T runWithTiming<T>(T callback()) {
+T runWithTiming<T>(T Function() callback) {
   var stopwatch = clock.stopwatch()..start();
   var result = callback();
   print('It took ${stopwatch.elapsed}!');

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,14 +1,13 @@
 name: clock
 version: 1.0.2-dev
 description: A fakeable wrapper for dart:core clock APIs
-author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/clock
 
 environment:
   sdk: '>=2.1.1 <3.0.0'
 
 dependencies:
-  meta: '>=0.9.0 <2.0.0'
+  meta: ^1.0.0
 
 dev_dependencies:
   test: ^1.0.0

--- a/test/stopwatch_test.dart
+++ b/test/stopwatch_test.dart
@@ -165,5 +165,7 @@ void main() {
         });
       });
     });
+  }, onPlatform: {
+    'js': const Skip('Web does not have enough precision'),
   });
 }


### PR DESCRIPTION
- Use `pub.dev` links over `dartdocs.org` in README.
- In example, follow `package:pedantic` style for function typed
  argument.
- Drop unused author field from pubspec.
- Use a simpler constraint on `package:meta` since the SDK constraint
  already prevents us from picking up older versions.
- Run tests on Travis. Fixes dart-lang/tools#698 