### PR TITLE
Pubspec description fix and example

### DIFF
--- a/example/lib/example.dart
+++ b/example/lib/example.dart
@@ -1,0 +1,19 @@
+import 'package:clock/clock.dart';
+
+class ClockExample {
+  /// returns the number of days from the current date to [future]
+  int daysFromNow(DateTime future) {
+    const maximumDstLoss = 1; // max hours lost to DST
+
+    // By using clock.now() instead of DateTime.now()
+    // unit tests can control the current time
+    var todayWithTime = clock.now();
+
+    var today =
+        DateTime(todayWithTime.year, todayWithTime.month, todayWithTime.day);
+    var tomorrow =
+        DateTime(future.year, future.month, future.day, maximumDstLoss);
+    var diff = tomorrow.difference(today);
+    return diff.inDays;
+  }
+}

--- a/example/lib/example.dart
+++ b/example/lib/example.dart
@@ -1,3 +1,7 @@
+// Copyright (c) 2017, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
 import 'package:clock/clock.dart';
 
 class ClockExample {

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -1,0 +1,19 @@
+name: clock_example
+description: Demonstrates how to use the clock package.
+version: 1.0.0
+
+environment:
+  sdk: ">=2.1.0 <3.0.0"
+
+dependencies:
+  flutter:
+    sdk: flutter
+  clock: ^1.0.1
+
+dev_dependencies:
+  flutter_test:
+    sdk: flutter
+  test: ^1.9.4
+  fake_async: ^1.0.1
+
+

--- a/example/test/example_test.dart
+++ b/example/test/example_test.dart
@@ -1,3 +1,7 @@
+// Copyright (c) 2017, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
 import 'package:clock_example/example.dart';
 import 'package:fake_async/fake_async.dart';
 import 'package:test/test.dart';

--- a/example/test/example_test.dart
+++ b/example/test/example_test.dart
@@ -1,0 +1,14 @@
+import 'package:clock_example/example.dart';
+import 'package:fake_async/fake_async.dart';
+import 'package:test/test.dart';
+
+void main() {
+  test('calculation works for DST', () {
+    // The use of fakeAsync here allows the initialTime to set the 
+    // value returned by clock.now() in the daysFromNow method. 
+    fakeAsync((testAsync) {
+      var example = ClockExample();
+      expect(example.daysFromNow(DateTime(2020, 3, 9)), 1);
+    }, initialTime: DateTime(2020, 3, 8));
+  });
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: clock
 version: 1.0.2-dev
-description: A fakeable wrapper for dart:core clock APIs
+description: A fakeable wrapper for dart:core clock APIs to reliably test timing-dependent code.
 homepage: https://github.com/dart-lang/clock
 
 environment:


### PR DESCRIPTION
This fixes a problem that analysis on pub.dev showed with the description in pubspec, and adds a small example of how to use the clock package with fake_async for testing. 

I've been using the clock and fake_async packages a lot and just wrote a blog post about them. While doing that I noticed that they hadn't been updated in a while and their pub.dev score is suffering. I see in the repo that there is a new version ready to post to pub-dev but not yet done. I'm hoping this small PR helps. There are no implementation changes in this PR, just example and docs. 
 
If you're interested in PRs like this I'll do the same for fake_async. 