### PR TITLE
Remove unnecessary cast from clamp computation.

### DIFF
--- a/lib/src/utils.dart
+++ b/lib/src/utils.dart
@@ -56,4 +56,4 @@ bool isLeapYear(int year) =>
 /// doesn't have 31-st date.
 int clampDayOfMonth(
         {required int year, required int month, required int day}) =>
-    day.clamp(1, daysInMonth(year, month)) as int;
+    day.clamp(1, daysInMonth(year, month));


### PR DESCRIPTION
Now that the analyzer correctly computes the type of `int.clamp(int,
int)` as `int` (for libraries opted into null safety), we no longer
need to cast the result to an `int`.