### PR TITLE
Bump SDK constraints for pub

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 1.1.0-nullsafety.3
+
+* Update SDK constraints to `>=2.12.0-0 <3.0.0` based on beta release
+  guidelines.
+
 ## 1.1.0-nullsafety.2
 
 * Allow prerelease versions of the 2.12 sdk.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,11 +1,10 @@
 name: clock
-version: 1.1.0-nullsafety.2
+version: 1.1.0-nullsafety.3
 description: A fakeable wrapper for dart:core clock APIs
 homepage: https://github.com/dart-lang/clock
 
 environment:
-  # This must remain a tight constraint until nnbd is stable
-  sdk: '>=2.10.0-0 <2.12.0'
+  sdk: ">=2.12.0-0 <3.0.0"
 
 dev_dependencies:
   test: ^1.16.0-nullsafety


### PR DESCRIPTION
Use a 2.12.0 lower bound since pub does not understand allowed
experiments for earlier versions.

Use a 3.0.0 upper bound to avoid a warning in pub and to give some
flexibility in publishing for stable.